### PR TITLE
Fix HttpClient closing too early in Ollama tasks

### DIFF
--- a/buildSrc/src/main/kotlin/io/violabs/mimir/buildsrc/ai/ollamaTestStartup/HttpManager.kt
+++ b/buildSrc/src/main/kotlin/io/violabs/mimir/buildsrc/ai/ollamaTestStartup/HttpManager.kt
@@ -93,8 +93,6 @@ class HttpManager private constructor(clientOverride: HttpClient? = null) {
         logger.error("Error sending request: ${e.message}")
         e.printStackTrace()
         null
-    } finally {
-        client.close()
         logger.debug("Completed call.")
     }
 

--- a/buildSrc/src/main/kotlin/io/violabs/mimir/buildsrc/ai/ollamaTestStartup/PullOnStartupTask.kt
+++ b/buildSrc/src/main/kotlin/io/violabs/mimir/buildsrc/ai/ollamaTestStartup/PullOnStartupTask.kt
@@ -23,7 +23,8 @@ open class PullOnStartupTask : OllamaModelTask() {
         logger.lifecycle("Checking if model exists: $model")
 
         val httpManager = HttpManager.instance()
-        val getApiUrl = "$protocol://$host:$port/api/tags"
+        try {
+            val getApiUrl = "$protocol://$host:$port/api/tags"
 
         // First check if model exists
         val self = this
@@ -64,6 +65,9 @@ open class PullOnStartupTask : OllamaModelTask() {
                 logger.error("Failed to pull model: $model")
                 throw OllamaException("Failed to pull model: $model", e)
             }
+        }
+        } finally {
+            httpManager.client.close()
         }
     }
 }


### PR DESCRIPTION
This PR fixes the issue with the Ollama pullOnStartup task where the HttpClient was being closed too early, causing coroutine job cancellation errors.

Changes:
- Removed `client.close()` from HttpManager's tryCall method
- Added `client.close()` in finally block of PullOnStartupTask
- This ensures client stays open for all HTTP operations in the task
- Prevents "Parent job is Completed" errors from closed client

These changes should help with the stability of the Ollama model pull operations by keeping the HTTP client open throughout all necessary API calls in a task.