### PR TITLE
Fix package scanning for Postgres module

### DIFF
--- a/database/postgres/src/main/kotlin/io/violabs/mimir/database/postgres/PostgresApplication.kt
+++ b/database/postgres/src/main/kotlin/io/violabs/mimir/database/postgres/PostgresApplication.kt
@@ -1,9 +1,13 @@
 package io.violabs.mimir.database.postgres
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = ["io.violabs.mimir"])
+@EntityScan("io.violabs.mimir")
+@EnableJpaRepositories("io.violabs.mimir")
 class PostgresApplication
 
 fun main(args: Array<String>) {


### PR DESCRIPTION
Adds proper package scanning and JPA configuration:

- Adds `scanBasePackages` to scan all `io.violabs.mimir` packages
- Adds `@EntityScan` for entity detection  
- Adds `@EnableJpaRepositories` for repository configuration

This fixes the failing tests in the postgres module.