### PR TITLE
fix: improve module path parsing in GitHub workflow

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -31,7 +31,7 @@ jobs:
         id: set-matrix
         run: |
           MODULES=$(echo '${{ steps.changed-files.outputs.all_changed_files }}' | \
-            grep -o '^[^/]*' | sort -u | grep -v '^$' | \
+            awk -F'/' '{print $1}' | grep -v '^$' | sort -u | \
             jq -R . | jq -s . || echo '[]')
           echo "matrix=${MODULES}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Fixes the module parsing in the GitHub workflow by:
- Using awk instead of grep for more reliable path parsing
- Reordering pipeline to better handle empty strings

This should resolve the current parsing errors in the workflow.