### PR TITLE
fix: improve module parsing with sed and jq

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -30,9 +30,7 @@ jobs:
       - name: Determine affected modules
         id: set-matrix
         run: |
-          MODULES=$(echo '${{ steps.changed-files.outputs.all_changed_files }}' | \
-            grep -o '^[^/]*' | sort -u | grep -v '^$' | \
-            jq -R . | jq -s . || echo '[]')
+          MODULES=$(echo '${{ steps.changed-files.outputs.all_changed_files }}' | sed 's/\\/\//g' | tr ' ' '\n' | cut -d'/' -f1 | sort -u | jq -R -s 'split("\n")[:-1]')
           echo "matrix=${MODULES}" >> $GITHUB_OUTPUT
 
   module-tests:


### PR DESCRIPTION
Changes the module parsing to handle paths more reliably by:
- Using sed to normalize path separators
- Splitting input into lines
- Using cut for consistent path extraction
- Proper array formatting with jq