### PR TITLE
Configure test filtering for core module

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,3 +6,20 @@ dependencies {
   implementation(kotlin("stdlib-jdk8"))
   implementation(kotlin("reflect"))
 }
+
+tasks.test {
+  filter {
+    // Excludes integration tests by default
+    excludeTestsMatching("*IT")
+    excludeTestsMatching("*IntegrationTest")
+  }
+}
+
+// Custom task for running integration tests
+tasks.register<Test>("integrationTest") {
+  group = "verification"
+  filter {
+    includeTestsMatching("*IT")
+    includeTestsMatching("*IntegrationTest")
+  }
+}


### PR DESCRIPTION
## Changes
- Configured default test task to exclude integration tests
- Added separate integrationTest task for running integration tests
- Allows for specific test filtering using Gradle's test filter

## Usage
- Run only unit tests: `./gradlew core:test`
- Run only integration tests: `./gradlew core:integrationTest`
- Run specific tests: `./gradlew core:test --tests "*ServiceTest"`

## Verification
Tested with dry-run that only core module tests are executed when running `./gradlew core:test`