### PR TITLE
Fix postgres test configuration

### DIFF
--- a/database/postgres/docker/docker-compose.yml
+++ b/database/postgres/docker/docker-compose.yml
@@ -16,6 +16,6 @@ services:
 
   test-postgres:
     <<: *postgres
-    profiles: [dev]
+    profiles: [test]
     ports:
-      - "5432:5432"
+      - "5433:5432"


### PR DESCRIPTION
This PR fixes issues with the postgres test configuration:

- Changed test-postgres service to use test profile instead of dev
- Updated test database port to 5433 to avoid conflicts with dev database
- Ensured proper service selection in docker-compose

These changes resolve the test failures in the database:postgres module by:
1. Using the correct profile (test) for test database container
2. Avoiding port conflicts between dev and test environments
3. Ensuring clean container startup and shutdown during tests

All tests are now passing successfully.